### PR TITLE
feat (kong): dbless kong and configurations

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,37 @@
+networks:
+  kong-net:
+    external: false
+
 services:
+  kong:
+    image: kong:latest
+    container_name: kong
+    user: kong
+    environment:
+      KONG_DATABASE: "off"
+      KONG_DECLARATIVE_CONFIG: "/kong/kong.yml"
+      KONG_PROXY_LISTEN: "0.0.0.0:8000"
+      KONG_ADMIN_LISTEN: "0.0.0.0:8001"
+      KONG_ADMIN_GUI_LISTEN: "0.0.0.0:8002"
+      KONG_ADMIN_ACCESS_LOG: /dev/stdout
+      KONG_ADMIN_ERROR_LOG: /dev/stderr
+      KONG_PROXY_ACCESS_LOG: /dev/stdout
+      KONG_PROXY_ERROR_LOG: /dev/stderr
+      KONG_PREFIX: /usr/local/kong
+    networks:
+      - kong-net
+    ports:
+      - "8000:8000/tcp"
+      - "8443:8443/tcp"
+      - "8001:8001/tcp"
+      - "8444:8444/tcp"
+      - "8002:8002/tcp"
+    volumes:
+      - ./kong/kong.yml:/kong/kong.yml:ro
+    restart: on-failure
+    security_opt:
+      - no-new-privileges
+  
   # fiat-service:
   #   container_name: fiat-service
   #   build:
@@ -15,7 +48,11 @@ services:
   #     - DATABASE_URL=postgresql://user:password@postgres:5432/fiat_db
   #   volumes:
   #     - fiat_data:/var/lib/fiat_service
-
+  #   networks:
+  #     - kong-net
+  #   expose:
+  #     - "5000"
+  
   # crypto-service:
   #   container_name: crypto-service
   #   build:
@@ -32,6 +69,10 @@ services:
   #     - DATABASE_URL=postgresql://user:password@postgres:5432/crypto_db
   #   volumes:
   #     - crypto_data:/var/lib/crypto_service
+  #   networks:
+  #     - kong-net
+  #   expose:
+  #     - "5000"
 
   user-service:
     container_name: user-service
@@ -53,6 +94,10 @@ services:
       - DB_PASS=password
     volumes:
       - user_data:/var/lib/user_service
+    networks:
+      - kong-net
+    expose:
+      - "5000"
 
   identity-service:
     container_name: identity-service
@@ -65,6 +110,10 @@ services:
       # - rabbitmq
       postgres:
         condition: service_healthy # wait until postgres healthy
+    networks:
+      - kong-net
+    expose:
+      - "5000"
 
   # rabbitmq:
   #   image: rabbitmq:management
@@ -91,6 +140,9 @@ services:
       interval: 5s
       retries: 5
       start_period: 10s
+    restart: on-failure
+    networks:
+      - kong-net
 
   # website:
   #   build:

--- a/kong/kong.yml
+++ b/kong/kong.yml
@@ -1,0 +1,18 @@
+_format_version: "3.0"
+
+services:
+  - name: user-service
+    url: http://user-service:5000  # Internal URL of the user service
+    routes:
+      - name: user-route
+        paths:
+          - /v1/api/user
+        strip_path: false
+
+  - name: identity-service
+    url: http://identity-service:5000  # Internal URL of the identity service
+    routes:
+      - name: identity-route
+        paths:
+          - /v1/api/identity
+        strip_path: false


### PR DESCRIPTION
#7 

## Context

- Reroute services to a central location
- Provide rate limiting
- Provide security and authentication

## Changes

- Set up dbless kong which refers to kong.yml for configurations
- Potential change needed to remove root paths for microservices `/v1/api` and then centralise url prefix. Will have to investigate further if this is possible

## Implementation Details

- Documentation for apis are still only accessible via respective localhost ports.
  - E.g. `localhost:5003/v1/api/user`
- Apis can be accessed via kong using localhost:8000
  - E.g. `localhost:8000/v1/api/user/account`

## How to Test

1. Standard docker compose up will work:
```
docker-compose up -d --build
```
2. Test the following:
```
E.g. `localhost:8000/v1/api/user/account`
```

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have tested the changes
- [ ] _(where applicable)_ I have added tests to cover my changes
- [ ] _(where applicable)_ I have updated the documentation accordingly