### PR TITLE
refactor: api path

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -219,11 +219,11 @@ user_output_model = account_ns.model(
 ### CRUD Example
 
 - Use your created Namespace variable as the flask app and pass in the routes. The API naming convention will follow the `API_ROOT` followed by `/{namespace}` and `/{specified-route}`. An example would be:
-  - `API_ROOT`: "/v1/api/user"
+  - `API_ROOT`: "/api/v1/user"
   - `namespace`: "account"
   - `specified-route`: ""
 ```
-localhost:5003/v1/api/user/account
+localhost:5003/api/v1/user/account
 ```
 - Use `expect` to specify the input parameters. Pass in the **input model** as the parameter.
 - Use `marshal_list_with` when you want to get all records. Pass in the **output model** as the parameter.
@@ -258,14 +258,14 @@ class UserAccountListResource(Resource):
 Each microservice hosts its documentation at:
 
 Atomic Microservices:
-- **Fiat Service:** `http://localhost:5001/v1/api/fiat`
-- **Crypto Service:** `http://localhost:5002/v1/api/crypto`
-- **User Service:** `http://localhost:5003/v1/api/user`
-- **transaction Service:** `http://localhost:5005/v1/api/transaction`
+- **Fiat Service:** `http://localhost:5001/api/v1/fiat`
+- **Crypto Service:** `http://localhost:5002/api/v1/crypto`
+- **User Service:** `http://localhost:5003/api/v1/user`
+- **transaction Service:** `http://localhost:5005/api/v1/transaction`
 
 Composite Microservices:
-- **identity** `http://localhost:5004/v1/api`
-- **deposit** `http://localhost:5006/v1/api`
+- **identity** `http://localhost:5004/api/v1`
+- **deposit** `http://localhost:5006/api/v1`
 
 
 ## Running the Website Locally

--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ Yorkshire Crypto Exchange is a microservices-based cryptocurrency exchange platf
 
 3. Access API documentation:
    - **Atomic microservices**
-      - **Fiat Service:** `http://localhost:5001/v1/api/fiat`
-      - **Crypto Service:** `http://localhost:5002/v1/api/crypto`
-      - **User Service:** `http://localhost:5003/v1/api/user`
-      - **transaction Service:** `http://localhost:5005/v1/api/transaction`
+      - **Fiat Service:** `http://localhost:5001/api/v1/fiat`
+      - **Crypto Service:** `http://localhost:5002/api/v1/crypto`
+      - **User Service:** `http://localhost:5003/api/v1/user`
+      - **transaction Service:** `http://localhost:5005/api/v1/transaction`
    - **Composite microservices**
-      - **identity** `http://localhost:5004/v1/api`
-      - **deposit** `http://localhost:5006/v1/api`
+      - **identity** `http://localhost:5004/api/v1`
+      - **deposit** `http://localhost:5006/api/v1`
 
 
 ## 📌 Features

--- a/api/atomic/fiat/app.py
+++ b/api/atomic/fiat/app.py
@@ -13,7 +13,7 @@ import os
 
 ##### Configuration #####
 API_VERSION = 'v1'
-API_ROOT = f'/{API_VERSION}/api/fiat'
+API_ROOT = f'/api/{API_VERSION}/fiat'
 
 app = Flask(__name__)
 CORS(app)

--- a/api/atomic/transaction/app.py
+++ b/api/atomic/transaction/app.py
@@ -15,7 +15,7 @@ from datetime import datetime
 ##### Configuration #####
 # Define API version and root path
 API_VERSION = 'v1'
-API_ROOT = f'/{API_VERSION}/api/transaction'
+API_ROOT = f'/api/{API_VERSION}/transaction'
 
 app = Flask(__name__)
 CORS(app)

--- a/api/atomic/user/app.py
+++ b/api/atomic/user/app.py
@@ -15,7 +15,7 @@ import os
 ##### Configuration #####
 # Define API version and root path
 API_VERSION = 'v1'
-API_ROOT = f'/{API_VERSION}/api/user'
+API_ROOT = f'/api/{API_VERSION}/user'
 
 app = Flask(__name__)
 CORS(app)

--- a/api/composite/deposit/app.py
+++ b/api/composite/deposit/app.py
@@ -12,7 +12,7 @@ from dotenv import load_dotenv
 ##### Configuration #####
 # Define API version and root path
 API_VERSION = 'v1'
-API_ROOT = f'/{API_VERSION}/api'
+API_ROOT = f'/api/{API_VERSION}'
 
 app = Flask(__name__)
 CORS(
@@ -47,8 +47,8 @@ app.register_blueprint(blueprint)
 # Environment variables for microservice
 # Environment variables for microservice URLs
 # NOTE: Do not use localhost here as localhost refer to this container itself
-TRANSACTION_SERVICE_URL = "http://transaction-service:5000/v1/api/transaction"
-FIAT_SERVICE_URL = "http://fiat-service:5000/v1/api/fiat"
+TRANSACTION_SERVICE_URL = "http://transaction-service:5000/api/v1/transaction"
+FIAT_SERVICE_URL = "http://fiat-service:5000/api/v1/fiat"
 
 # Define namespaces to group api calls together
 # Namespaces are essentially folders that group all related API calls
@@ -122,8 +122,8 @@ class CreateDeposit(Resource):
 
         # Construct success and cancel URLs
         base_url = request.host_url.rstrip('/')
-        success_url = f"{base_url}/v1/api/deposit/success/{transaction_id}"
-        cancel_url = f"{base_url}/v1/api/deposit/cancel/{transaction_id}"
+        success_url = f"{base_url}/api/v1/deposit/success/{transaction_id}"
+        cancel_url = f"{base_url}/api/v1/deposit/cancel/{transaction_id}"
 
         try:
             # Create Stripe checkout session

--- a/api/composite/identity/app.py
+++ b/api/composite/identity/app.py
@@ -7,7 +7,7 @@ import requests
 ##### Configuration #####
 # Define API version and root path
 API_VERSION = 'v1'
-API_ROOT = f'/{API_VERSION}/api'
+API_ROOT = f'/api/{API_VERSION}'
 
 app = Flask(__name__)
 CORS(app)
@@ -23,9 +23,9 @@ app.register_blueprint(blueprint)
 # Environment variables for microservice
 # Environment variables for microservice URLs
 # NOTE: Do not use localhost here as localhost refer to this container itself
-USERS_SERVICE_URL = "http://user-service:5000/v1/api/user"
-FIAT_SERVICE_URL = "http://fiat-service:5000/v1/api/fiat"
-CRYPTO_SERVICE_URL = "http://crypto-service:5000/v1/api/crypto"
+USERS_SERVICE_URL = "http://user-service:5000/api/v1/user"
+FIAT_SERVICE_URL = "http://fiat-service:5000/api/v1/fiat"
+CRYPTO_SERVICE_URL = "http://crypto-service:5000/api/v1/crypto"
 
 # Define namespaces to group api calls together
 # Namespaces are essentially folders that group all related API calls

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -169,7 +169,7 @@ services:
   stripe-cli:
     image: stripe/stripe-cli:latest
     container_name: stripe-cli
-    command: listen --api-key ${STRIPE_SECRET_KEY} --forward-to deposit-service:5000/v1/api/deposit/webhook
+    command: listen --api-key ${STRIPE_SECRET_KEY} --forward-to deposit-service:5000/api/v1/deposit/webhook
     environment:
       - STRIPE_API_KEY=${STRIPE_SECRET_KEY}
       - STRIPE_DEVICE_NAME=local_dev

--- a/kong/kong.yml
+++ b/kong/kong.yml
@@ -7,7 +7,7 @@ services:
     routes:
       - name: user-route
         paths:
-          - /v1/api/user
+          - /api/v1/user
         strip_path: false
 
   - name: fiat-service
@@ -15,7 +15,7 @@ services:
     routes:
       - name: fiat-route
         paths:
-          - /v1/api/fiat
+          - /api/v1/fiat
         strip_path: false
 
   - name: identity-service
@@ -23,7 +23,7 @@ services:
     routes:
       - name: identity-route
         paths:
-          - /v1/api/identity
+          - /api/v1/identity
         strip_path: false
 
   - name: transaction-service
@@ -31,5 +31,5 @@ services:
     routes:
       - name: transaction-route
         paths:
-          - /v1/api/transaction
+          - /api/v1/transaction
         strip_path: false


### PR DESCRIPTION
closes #24

## Context

Changed the API base route from `/v1/api/` to `/api/v1/` for consistency and to follow common RESTful API design patterns.  
This affects all services and API calls in the system.

## Changes

- Updated all route definitions from `/v1/api/` to `/api/v1/`.
- Adjusted relevant controller, router, and client configurations.
- Updated environment variables, configs, and documentation where applicable.
  
## Implementation Details

This change involved:
- Refactoring all service-level routes (Flask / Express / etc.) to use `/api/v1/` as the new base path.
- Adjusting internal service calls where services communicate with each other.
- Verified and tested using Docker Compose by running all services and testing API endpoints manually.
- No breaking changes were observed beyond the intended route change.

## How to Test

1. Pull this branch.
2. Run `docker-compose up --build`.
3. Access all APIs using the new base path `/api/v1/...`.
4. Verify that all endpoints behave as expected.
5. Confirm that all services start up correctly without errors.

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have tested the changes
- [ ] _(where applicable)_ I have added tests to cover my changes
- [x] _(where applicable)_ I have updated the documentation accordingly