### PR TITLE
refactor: remove address requirements

### DIFF
--- a/api/composite/identity/app.py
+++ b/api/composite/identity/app.py
@@ -50,19 +50,19 @@ create_account_model = identity_ns.model(
         # Authenticate fields
         "password": fields.String(required=True, description="User Password"),
 
-        # Address fields
-        'streetNumber': fields.String(attribute='street_number',required=True, description='The street number'),
-        'streetName': fields.String(attribute='street_name',required=True, description='The street name'),
+        # # Address fields
+        # 'streetNumber': fields.String(attribute='street_number',required=True, description='The street number'),
+        # 'streetName': fields.String(attribute='street_name',required=True, description='The street name'),
 
-        # # Nullable fields inside address
-        'unitNumber': fields.String(attribute='unit_number',required=False, description='The unit number'),
-        'buildingName': fields.String(attribute='building_name',required=False, description='The building name'),
-        'district': fields.String(attribute='district',required=False, description='The district'),
+        # # # Nullable fields inside address
+        # 'unitNumber': fields.String(attribute='unit_number',required=False, description='The unit number'),
+        # 'buildingName': fields.String(attribute='building_name',required=False, description='The building name'),
+        # 'district': fields.String(attribute='district',required=False, description='The district'),
 
-        'city': fields.String(required=True, description='The city'),
-        'stateProvince': fields.String(attribute='state_province',required=True, description='The state or province'),
-        'postalCode': fields.String(attribute='postal_code',required=True, description='The postal code'),
-        'country': fields.String(required=True, description='The country')
+        # 'city': fields.String(required=True, description='The city'),
+        # 'stateProvince': fields.String(attribute='state_province',required=True, description='The state or province'),
+        # 'postalCode': fields.String(attribute='postal_code',required=True, description='The postal code'),
+        # 'country': fields.String(required=True, description='The country')
     },
 )
 
@@ -104,19 +104,20 @@ class CreateAccount(Resource):
         phone = data.get("phone")
         email = data.get("email")
 
-        # Address Fields
-        street_number = data.get("streetNumber")
-        street_name = data.get("streetName")
-        unit_number = data.get("unitNumber")
-        building_name = data.get("buildingName")
-        district = data.get("district")
-        city = data.get("city")
-        state_province = data.get("stateProvince")
-        postal_code = data.get("postalCode")
-        country = data.get("country")
+        # # Address Fields
+        # street_number = data.get("streetNumber")
+        # street_name = data.get("streetName")
+        # unit_number = data.get("unitNumber")
+        # building_name = data.get("buildingName")
+        # district = data.get("district")
+        # city = data.get("city")
+        # state_province = data.get("stateProvince")
+        # postal_code = data.get("postalCode")
+        # country = data.get("country")
 
         # Validate required fields properly
-        required_fields = [username, password, fullname, phone, email, country, street_number, street_name, city, state_province, postal_code]
+        # required_fields = [username, password, fullname, phone, email, country, street_number, street_name, city, state_province, postal_code]
+        required_fields = [username, password, fullname, phone, email]
         if None in required_fields or "" in required_fields:
             return {"error": "Missing required fields"}, 400  # Bad request response
 
@@ -160,35 +161,34 @@ class CreateAccount(Resource):
         except requests.RequestException as e:
             return {"error": "Failed to connect to authentication service", "details": str(e)}, 500
 
-        # Store address details in address under user microservice
-        user_address_payload = {
-            "streetNumber": street_number,
-            "streetName": street_name,
-            "unitNumber": unit_number,
-            "buildingName": building_name,
-            "district": district,
-            "city": city,
-            "stateProvince": state_province,
-            "postalCode": postal_code,
-            "country": country
-        }
+        # # Store address details in address under user microservice
+        # user_address_payload = {
+        #     "streetNumber": street_number,
+        #     "streetName": street_name,
+        #     "unitNumber": unit_number,
+        #     "buildingName": building_name,
+        #     "district": district,
+        #     "city": city,
+        #     "stateProvince": state_province,
+        #     "postalCode": postal_code,
+        #     "country": country
+        # }
 
-        try:
-            address_response = requests.post(f"{USERS_SERVICE_URL}/address/{user_id}", json=user_address_payload)
-            if address_response.status_code != 201:
-                return {
-                    "error": "Failed to store user address",
-                    "details": address_response.json() if address_response.content else "No response content"
-                }, address_response.status_code
-        except requests.RequestException as e:
-            return {"error": "Failed to connect to address service", "details": str(e)}, 500
+        # try:
+        #     address_response = requests.post(f"{USERS_SERVICE_URL}/address/{user_id}", json=user_address_payload)
+        #     if address_response.status_code != 201:
+        #         return {
+        #             "error": "Failed to store user address",
+        #             "details": address_response.json() if address_response.content else "No response content"
+        #         }, address_response.status_code
+        # except requests.RequestException as e:
+        #     return {"error": "Failed to connect to address service", "details": str(e)}, 500
 
-        return {"message": "User account successfully created", "user_id": user_id}, 201
-    
         # Create fiat wallet using fiat microservice
 
         # Create crypto wallet using crypto microservice
 
+        return {"message": "User account successfully created", "user_id": user_id}, 201
 
 # Add name spaces into api
 api.add_namespace(identity_ns)


### PR DESCRIPTION
#23 

## Context
In our website, no fields created for address. Even though in real life, we require the storage of PII for KYC, for demonstration purposes, this might be too granular. 

## Changes
- Commented out all address code. It is possible to uncomment the address fields if required.
- For user service, you're able to create account, authenticate, and address separately. However, to create authenticate or address, you require an account. Upon deletion of account, both authenticate and address will be deleted.
- Tested on docker, nothing broke.

## Implementation Details
- Commented out address related code on identity service.

## How to Test
```
docker-compose down -v
docker-compose up -d --build
```
visit [identity documentation](http://localhost:5004/api/v1/) to create an account.

## Preview / Screenshots
![{50EE0DC7-A478-46EA-818C-FCA58F0D21CC}](https://github.com/user-attachments/assets/27aed573-257b-4b71-aa95-50c5938e557b)

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have tested the changes
- [ ] _(where applicable)_ I have added tests to cover my changes
- [ ] _(where applicable)_ I have updated the documentation accordingly