### PR TITLE
refactor: removed fiat account dependency on fiat currency

### DIFF
--- a/api/atomic/fiat/app.py
+++ b/api/atomic/fiat/app.py
@@ -75,7 +75,6 @@ class FiatAccount(db.Model):
     balance = db.Column(db.Numeric(18, 8), nullable=False, default=0.0)
     currency_code = db.Column(
         db.String(3),
-        db.ForeignKey('fiat_currency.currency_code'),
         primary_key=True,
         nullable=False
     )

--- a/api/atomic/fiat/migrations/versions/8a9c144bdecc_initial_migration.py
+++ b/api/atomic/fiat/migrations/versions/8a9c144bdecc_initial_migration.py
@@ -29,7 +29,6 @@ def upgrade():
     sa.Column('balance', sa.Numeric(precision=18, scale=8), nullable=False),
     sa.Column('currency_code', sa.String(length=3), nullable=False),
     sa.Column('updated', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True),
-    sa.ForeignKeyConstraint(['currency_code'], ['fiat_currency.currency_code'], ),
     sa.PrimaryKeyConstraint('user_id', 'currency_code')
     )
     # ### end Alembic commands ###


### PR DESCRIPTION
#23 

## Context
Fiat account has a depedency on fiat currency table as it required the currency to be already created before it can create a new account. This can make testing difficult for now. Since we have an exchange API, this might not be that relevant anymore and shall be used as a back up.

## Changes
- fiat currency table will be semi useless now with the external exchange API
- tested and fiat account can create accounts even if currencyCode doesn't exists in currency table

## How to Test
- Creating an account with a currencyCode that doesn't exist in currency t able should still be possible.

## Preview / Screenshots
![{EC0DB6B2-C528-4ECF-809B-3B8AB54240B9}](https://github.com/user-attachments/assets/2b16c976-f256-4b72-80f0-19d7afc9a402)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have tested the changes
- [ ] _(where applicable)_ I have added tests to cover my changes
- [ ] _(where applicable)_ I have updated the documentation accordingly