### PR TITLE
Refactor: crypto naming convention

### DIFF
--- a/api/atomic/crypto/migrations/versions/13749c5d948a_reinitalise_tables.py
+++ b/api/atomic/crypto/migrations/versions/13749c5d948a_reinitalise_tables.py
@@ -22,7 +22,7 @@ def upgrade():
     sa.Column('user_id', sa.String(length=100), nullable=False),
     sa.Column('token_id', sa.String(length=15), nullable=False),
     sa.Column('actual_balance', sa.Float(), nullable=False),
-    sa.Column('held_balance', sa.Float(), nullable=False),
+    sa.Column('available_balance', sa.Float(), nullable=False),
     sa.Column('updated_on', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True),
     sa.PrimaryKeyConstraint('user_id', 'token_id')
     )

--- a/api/atomic/crypto/seeddata.json
+++ b/api/atomic/crypto/seeddata.json
@@ -33,7 +33,7 @@
       "walletId": "ba6bdb39-3459-45e4-8bfc-b6bcd1c13e6d",
       "tokenId": "BTC",
       "actualBalance": 2.5,
-      "heldBalance": 1.0,
+      "availableBalance": 1.0,
       "updatedOn": "2025-03-25T12:30:00Z"
     },
     {
@@ -41,7 +41,7 @@
       "walletId": "4a90f019-b02a-450f-a8ff-d68cc6b848eb",
       "tokenId": "XRP",
       "actualBalance": 1000,
-      "heldBalance": 500,
+      "availableBalance": 500,
       "updatedOn": "2025-03-25T12:30:00Z"
     },
     {
@@ -49,7 +49,7 @@
       "walletId": "724e3519-9db0-4c02-b627-d0b2fe8e56d0",
       "tokenId": "SOL",
       "actualBalance": 10,
-      "heldBalance": 2,
+      "availableBalance": 2,
       "updatedOn": "2025-03-25T12:30:00Z"
     },
     {
@@ -57,7 +57,7 @@
       "walletId": "ba6bdb39-3459-45e4-8bfc-b6bcd1c13e6d",
       "tokenId": "XRP",
       "actualBalance": 500,
-      "heldBalance": 100,
+      "availableBalance": 100,
       "updatedOn": "2025-03-25T12:30:00Z"
     },
     {
@@ -65,7 +65,7 @@
       "walletId": "4a90f019-b02a-450f-a8ff-d68cc6b848eb",
       "tokenId": "SOL",
       "actualBalance": 50,
-      "heldBalance": 5,
+      "availableBalance": 5,
       "updatedOn": "2025-03-25T12:30:00Z"
     }
   ]

--- a/api/composite/ramp/app.py
+++ b/api/composite/ramp/app.py
@@ -277,7 +277,7 @@ def check_crypto_holding(user_id, token_id):
 def deposit_crypto(user_id, token_id, amount):
     """
     Deposit crypto into a user's holding.
-    Increases both actual and held balance.
+    Increases both actual and available balance.
     
     Args:
         user_id (str): The user ID
@@ -313,7 +313,7 @@ def deposit_crypto(user_id, token_id, amount):
 def withdraw_crypto(user_id, token_id, amount):
     """
     Withdraw crypto from a user's holding.
-    Reduces both actual and held balance.
+    Reduces both actual and available balance.
     
     Args:
         user_id (str): The user ID
@@ -363,7 +363,7 @@ def create_crypto_holding(user_id, token_id, amount):
             "userId": user_id,
             "tokenId": token_id,
             "actualBalance": amount,
-            "heldBalance": amount  # Set both balances to the same amount
+            "availableBalance": amount  # Set both balances to the same amount
         }
         response = requests.post(f"{CRYPTO_SERVICE_URL}/holdings", json=payload)
         if response.status_code == 201:
@@ -758,9 +758,9 @@ class SwapResource(Resource):
         if 'error' in crypto_holding:
             return crypto_holding, 500
         
-        # Step 2: Check if crypto holding has sufficient held balance
-        if crypto_holding['heldBalance'] < crypto_amount:
-            return {'error': 'Insufficient balance', 'message': f"Insufficient {token_id} balance. Required: {crypto_amount}, Available: {crypto_holding['heldBalance']}"}, 400
+        # Step 2: Check if crypto holding has sufficient available balance
+        if crypto_holding['availableBalance'] < crypto_amount:
+            return {'error': 'Insufficient balance', 'message': f"Insufficient {token_id} balance. Required: {crypto_amount}, Available: {crypto_holding['availableBalance']}"}, 400
         
         # Step 3: Get exchange rate from crypto to fiat
         # Assume crypto amount is in USD equivalent

--- a/website/yorkshire-crypto-exchange/app/dashboard/ramp/page.tsx
+++ b/website/yorkshire-crypto-exchange/app/dashboard/ramp/page.tsx
@@ -201,9 +201,9 @@ export default function RampPage() {
       const account = fiatAccounts.find(acc => acc.currencyCode.toLowerCase() === fromCurrency.toLowerCase());
       return account ? account.balance : 0;
     } else {
-      // For crypto to fiat transactions, check USDT held balance
+      // For crypto to fiat transactions, check USDT available balance
       const holding = cryptoHoldings.find(h => h.tokenId.toLowerCase() === fromCurrency.toLowerCase());
-      return holding ? holding.heldBalance : 0;
+      return holding ? holding.availableBalance : 0;
     }
   };
 
@@ -535,7 +535,7 @@ export default function RampPage() {
                       ${parseFloat(holding.actualBalance.toFixed(2)).toLocaleString(undefined, { minimumFractionDigits: 2 })}
                     </div>
                     <div className="text-sm text-muted-foreground">
-                      Available: ${parseFloat(holding.heldBalance.toFixed(2)).toLocaleString(undefined, { minimumFractionDigits: 2 })}
+                      Available: ${parseFloat(holding.availableBalance.toFixed(2)).toLocaleString(undefined, { minimumFractionDigits: 2 })}
                     </div>
                   </CardContent>
                 </Card>


### PR DESCRIPTION
## Context
Originally, held balance was used to determine how much money a user cannot use to trade. However, to make it more robust for data showing, we have decided to show the available balance instead of held balance. 

## Changes
- Changed `heldBalance` to `availableBalance` for clarity.

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have tested the changes
- [ ] _(where applicable)_ I have added tests to cover my changes
- [ ] _(where applicable)_ I have updated the documentation accordingly