### PR TITLE
Feat: origin and jwt env

### DIFF
--- a/api/atomic/user/app.py
+++ b/api/atomic/user/app.py
@@ -37,6 +37,8 @@ reset_tokens = {}
 
 # Detect if running inside Docker
 RUNNING_IN_DOCKER = os.getenv("RUNNING_IN_DOCKER", "false").lower() == "true"
+JWT_KEY = os.getenv("JWT_KEY", "iloveesd")
+JWT_SECRET = os.getenv("JWT_SECRET", "esdisfun")
 
 # Set Database Configuration Dynamically
 if RUNNING_IN_DOCKER:
@@ -307,12 +309,12 @@ def generate_jwt_token(user_id):
         'sub': str(user_id),
         'exp': int(time.time()) + 3600,  # 1 hour expiry
         'iat': int(time.time()),
-        'kid': 'iloveesd',  # Must match your Kong configuration
-        'iss': 'iloveesd'   # Add the issuer claim with the same value as kid
+        'kid': JWT_KEY,  # Must match your Kong configuration
+        'iss': JWT_KEY   # Add the issuer claim with the same value as kid
     }
 
     # Create the token using the same secret defined in Kong
-    token = jwt.encode(payload, 'esdisfun', algorithm='HS256')
+    token = jwt.encode(payload, JWT_SECRET, algorithm='HS256')
     return token
 
 def send_reset_email(to_email, reset_link):

--- a/api/composite/identity/app.py
+++ b/api/composite/identity/app.py
@@ -4,7 +4,8 @@ from flask_restx import Api, Resource, fields, Namespace
 import requests
 import jwt
 import time
-
+import os
+from dotenv import load_dotenv
 
 ##### Configuration #####
 # Define API version and root path
@@ -13,6 +14,11 @@ API_ROOT = f'/api/{API_VERSION}'
 
 app = Flask(__name__)
 CORS(app)
+
+# Load environment variables
+load_dotenv()
+JWT_KEY = os.getenv("JWT_KEY", "iloveesd")
+JWT_SECRET = os.getenv("JWT_SECRET", "esdisfun")
 
 # Flask swagger (flask_restx) api documentation
 # Creates API documentation automatically
@@ -256,12 +262,12 @@ class CreateAccount(Resource):
             'sub': str(user_id),
             'exp': int(time.time()) + 3600,  # 1 hour expiry
             'iat': int(time.time()),
-            'kid': 'iloveesd',  # Must match your Kong configuration
-            'iss': 'iloveesd'   # Add the issuer claim with the same value as kid
+            'kid': JWT_KEY,  # Must match your Kong configuration
+            'iss': JWT_KEY   # Add the issuer claim with the same value as kid
         }
 
         # Create the token using the same secret defined in Kong
-        token = jwt.encode(payload, 'esdisfun', algorithm='HS256')
+        token = jwt.encode(payload, JWT_SECRET, algorithm='HS256')
         
         return {"message": "User account successfully created", "userId": user_id, "token": token}, 201
 

--- a/api/composite/identity/requirements.txt
+++ b/api/composite/identity/requirements.txt
@@ -4,3 +4,4 @@ pika
 Flask-Cors
 Requests
 PyJWT
+Dotenv

--- a/kong/kong.yml
+++ b/kong/kong.yml
@@ -5,6 +5,7 @@ plugins:
     config:
       origins:
         - http://localhost:3000
+        - https://yorkshirecryptoexchange.com
       methods:
         - GET
         - POST
@@ -42,9 +43,9 @@ consumers:
 
 jwt_secrets:
   - consumer: app_client
-    key: "iloveesd"
-    secret: "esdisfun"
-    algorithm: HS256
+    key: "yce_client_prod"
+    secret: "421j31d12das9021djas0124l"
+    algorithm: "HS256"
 
 services:
   - name: user-service

--- a/swagger-docs/requirements.txt
+++ b/swagger-docs/requirements.txt
@@ -1,3 +1,3 @@
-Flask==2.0.1
-requests==2.26.0
-Werkzeug==2.0.3
+Flask
+requests
+Werkzeug

--- a/website/yorkshire-crypto-exchange/app/middleware.ts
+++ b/website/yorkshire-crypto-exchange/app/middleware.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import jwt from "jsonwebtoken";
 
-const SECRET = "esdisfun"; // Must match your backend exactly
+const SECRET = process.env.JWT_SECRET || "esdisfun";
 
 export async function middleware(request: NextRequest) {
   const token = request.cookies.get("jwt_token")?.value;


### PR DESCRIPTION
## Context
Didn't want to hardcode JWT, refer to .env instead. 

## Changes
- Refer to JWT using ,env
- Added origin to include domain name yorkshirecryptoexchange.com

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have tested the changes
- [ ] _(where applicable)_ I have added tests to cover my changes
- [ ] _(where applicable)_ I have updated the documentation accordingly