### PR TITLE
Fix: API gateway routing

### DIFF
--- a/website/yorkshire-crypto-exchange/app/forgot-password/page.tsx
+++ b/website/yorkshire-crypto-exchange/app/forgot-password/page.tsx
@@ -16,7 +16,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-const API_GATEWAY_URL = process.env.API_GATEWAY_URL;
+const API_GATEWAY_URL = process.env.NEXT_PUBLIC_API_GATEWAY_URL;
 
 export default function ForgotPasswordPage() {
   const [email, setEmail] = useState("");

--- a/website/yorkshire-crypto-exchange/app/login/page.tsx
+++ b/website/yorkshire-crypto-exchange/app/login/page.tsx
@@ -20,7 +20,7 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-const API_GATEWAY_URL = process.env.API_GATEWAY_URL;
+const API_GATEWAY_URL = process.env.NEXT_PUBLIC_API_GATEWAY_URL;
 
 export default function LoginPage() {
   const { login } = useAuth();

--- a/website/yorkshire-crypto-exchange/app/reset-password/[token]/page.tsx
+++ b/website/yorkshire-crypto-exchange/app/reset-password/[token]/page.tsx
@@ -17,7 +17,7 @@ import {
 import Link from "next/link";
 import { Eye, EyeOff, Loader2 } from "lucide-react";
 import { useAuth } from "@/components/AuthProvider";
-const API_GATEWAY_URL = process.env.API_GATEWAY_URL;
+const API_GATEWAY_URL = process.env.NEXT_PUBLIC_API_GATEWAY_URL;
 
 export default function ResetPasswordPage() {
   const router = useRouter();

--- a/website/yorkshire-crypto-exchange/app/signup/page.tsx
+++ b/website/yorkshire-crypto-exchange/app/signup/page.tsx
@@ -20,7 +20,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { setCookie, getCookie } from "@/lib/cookies";
-const API_GATEWAY_URL = process.env.API_GATEWAY_URL;
+const API_GATEWAY_URL = process.env.NEXT_PUBLIC_API_GATEWAY_URL;
 
 export default function SignupPage() {
   const { login } = useAuth();

--- a/website/yorkshire-crypto-exchange/lib/axios.ts
+++ b/website/yorkshire-crypto-exchange/lib/axios.ts
@@ -1,7 +1,7 @@
 // lib/axios.ts
 import axios from "axios";
 import { getCookie } from "@/lib/cookies";
-const API_GATEWAY_URL = process.env.API_GATEWAY_URL;
+const API_GATEWAY_URL = process.env.NEXT_PUBLIC_API_GATEWAY_URL;
 
 const instance = axios.create({
   baseURL: API_GATEWAY_URL,


### PR DESCRIPTION
- In Next.js, client components (marked with "use client") cannot directly access regular environment variables.
## Checklist

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [ ] I have tested the changes
- [ ] _(where applicable)_ I have added tests to cover my changes
- [ ] _(where applicable)_ I have updated the documentation accordingly